### PR TITLE
Removed !important and added inline styles

### DIFF
--- a/custom_bootstrap.css
+++ b/custom_bootstrap.css
@@ -1583,7 +1583,7 @@ pre code {
   overflow-y: scroll;
 }
 .container {
-    width: 1250px !important;
+    width: 1250px;
   padding-right: 15px;
   padding-left: 15px;
   margin-right: auto;

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 Glad you are interested in the code.
 
 Contribute here
-	
+
 	https://github.com/VaTz88/VIT-Time-Table-Visualizer
 
 -->
@@ -18,7 +18,7 @@ Contribute here
     <META NAME="Keywords" CONTENT="VIT, University, FFCS, On, The, Go, Time, Table, Visualizer">
     <META NAME="distribution" CONTENT="Global">
     <META NAME="country" CONTENT="India">
-    
+
     <meta property="og:title" content="FFCS On The Go" />
     <meta property="og:url" content="http://ffcsonthego.azurewebsites.net/" />
     <meta property="og:image" content="https://raw.githubusercontent.com/VaTz88/VIT-Time-Table-Visualizer/master/FFCSonTheGoMetaImg.png" />
@@ -72,7 +72,7 @@ Contribute here
 </script>
 
 <!--Website content-->
-    <div class="container">
+    <div class="container" style="width: 1250px">
         <div class="row">
             <div class="col-xs-6"><h1>VIT TIMETABLE VISUALIZER</h1></div>
             <!--Quick start guide
@@ -186,7 +186,9 @@ Contribute here
             <div class="col-xs-1 TimetableContent TDD2" style="padding-top:10px; padding-bottom:10px;">TDD2 / L59</div>
             <div class="col-xs-1 TimetableContent" style="padding-top:20px; padding-bottom:20px;">L60</div>
         </div>
+      </div>
 
+      <div class="container" style="width:1250px">
         <!--Slot tiles-->
         <div style="padding-top: 8px; padding-bottom: 8px">
         <div class="row">
@@ -339,6 +341,6 @@ Contribute here
       });
     });
     </script>
-    
+
 </body>
 </html>


### PR DESCRIPTION
I am working on a feature for directly inputting the slot from the user but the whole thing looks messed up since you have an `!important` declaration in the CSS. These changes work just as fine but won't  interfere with other responsive content we add in the future.